### PR TITLE
Fix: Backend service fails to start due to missing JAR file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+build
+.gradle


### PR DESCRIPTION
The backend service was failing to start because the JAR file could not be found. This was caused by the local 'build' directory being copied into the Docker image, which interfered with the build process inside the container.

This change adds a .dockerignore file to exclude the 'build' and '.gradle' directories from the Docker context, ensuring a clean build within the container.